### PR TITLE
Fix build for zig 0.12.0 and add rayllib-zig dependency via `build.zig.zon`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "raylib-zig"]
-	path = raylib-zig
-	url = https://github.com/Not-Nik/raylib-zig

--- a/build.zig
+++ b/build.zig
@@ -1,17 +1,25 @@
 const std = @import("std");
-const rl = @import("raylib-zig/build.zig");
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    var raylib = rl.getModule(b, "raylib-zig");
-    var raylib_math = rl.math.getModule(b, "raylib-zig");
+
+    const raylib_dep = b.dependency("raylib-zig", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const raylib = raylib_dep.module("raylib");
+    const raylib_math = raylib_dep.module("raylib-math");
+    const rlgl = raylib_dep.module("rlgl");
+    const raylib_artifact = raylib_dep.artifact("raylib");
 
     const exe = b.addExecutable(.{ .name = "lsr", .root_source_file = .{ .path = "src/main.zig" }, .optimize = optimize, .target = target });
 
-    rl.link(b, exe, target, optimize);
-    exe.addModule("raylib", raylib);
-    exe.addModule("raylib-math", raylib_math);
+    exe.linkLibrary(raylib_artifact);
+    exe.root_module.addImport("raylib", raylib);
+    exe.root_module.addImport("raylib-math", raylib_math);
+    exe.root_module.addImport("rlgl", rlgl);
 
     const run_cmd = b.addRunArtifact(exe);
     const run_step = b.step("run", "run");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,5 +13,11 @@
         "src",
         "LICENSE",
         "README.txt",
+        "asteroid.wav",
+        "bloop_hi.wav",
+        "bloop_lo.wav",
+        "explode.wav",
+        "shoot.wav",
+        "thrust.wav",
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,17 @@
 .{
-    .name = "raylib-zig",
-    .version = "0.1.1",
+    .name = "zigsteroids",
+    .version = "0.0.1",
     .dependencies = .{
-        .raylib = .{
-            .url = "https://github.com/raysan5/raylib/archive/5.0.tar.gz",
-            .hash = "1220c28847ca8e8756734ae84355802b764c9d9cf4de057dbc6fc2b15c56e726f27b",
+        .@"raylib-zig" = .{
+            .url = "git+https://github.com/Not-Nik/raylib-zig.git#ae533ad60fa31e5fc4fe4c4551002305f85c397e",
+            .hash = "1220fa78e6bd9eae16393b1d842ba653445e7863589c39874ff1e1e9a3ff2b78e53b",
         },
     },
-    .paths = .{""},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "LICENSE",
+        "README.txt",
+    },
 }


### PR DESCRIPTION
This PR fixes zigsteroids build in zig 0.12.0. It also removes `raylib-zig` submodule and uses `build.zig.zon` instead.